### PR TITLE
Filter teams by competition and season when creating an event.

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-sp-meta-box-event-teams.php
+++ b/includes/admin/post-types/meta-boxes/class-sp-meta-box-event-teams.php
@@ -55,6 +55,10 @@ class SP_Meta_Box_Event_Teams {
 				</p>
 				<p class="sp-tab-select sp-title-generator">
 				<?php
+				$league = get_term( $league_id, 'sp_league' );
+				$league_slug = $league->slug;
+				$season = get_term( $season_id, 'sp_season' );
+				$season_slug = $season->slug;
 				$args = array(
 					'post_type' => 'sp_team',
 					'name' => 'sp_team[]',
@@ -63,6 +67,8 @@ class SP_Meta_Box_Event_Teams {
 					'values' => 'ID',
 					'selected' => $team,
 					'chosen' => true,
+					'sp_league' => $league_slug,
+					'sp-season' => $season_slug,
 				);
 				sp_dropdown_pages( $args );
 				?>


### PR DESCRIPTION
Hi ThemeBoy,

Since yesterday, I have been testing out your Wonderful SportsPress plugin and it's just breathtaking in the sense that every time I told myself "aha, it lacks this feature", I found some minutes later that it did implement it and in a better way than I expected.

The only thing that I noticed (I think you just missed it by testing with a small set of 3 or 4 teams) is that when you have multiple divisons and competitions or different teams across seasons, you end up with a long list of teams.

So to make it more user friendly while creating an event, it will be good to filter the list of teams when one has selected the competition and the season.
The way it works with my fix is that you first create the event by setting the competition (league) and/or season and optionally the date ...etc... after what you save the event. Then, if you click on the teams dropdown, it will be a filtered subset of your teams list according to the competition (league) and season you have chosen before saving.
If you decide to edit the the competitoon (league) or season, you will need to save again in order to have an updated filtered list.

If you have chosen a competition for example, then saved, then chosen a team from that competion and saved, then edited to a different competion to which your chosen team doesn't belong, then the team field will be reset to 'None' and you will have the ability to choose from the updated filtered list.

SportsPress is literally the best plugin I have ever seen. It has 99% of what it needs to have except from the little suggestion I made above.

Cordially, Mounir.