### PR TITLE
iCal feed enhancements/improvements

### DIFF
--- a/feeds/ical.php
+++ b/feeds/ical.php
@@ -14,8 +14,14 @@ if ( 'sp_calendar' !== get_post_type( $post ) ) {
 	wp_die( __( 'ERROR: This is not a valid feed template.', 'sportspress' ), '', array( 'response' => 404 ) );
 }
 
+// Escapes a string of characters
+function escapeString($string) {
+  return preg_replace('/([\,;])/','\\\$1', $string);
+}
+
 // Get events in calendar
 $calendar = new SP_Calendar( $post );
+$postcontent = "$post->post_content";
 $events = $calendar->data();
 
 // Get blog locale
@@ -77,7 +83,7 @@ foreach ( $events as $event):
 		// Add details to location
 		$address = sp_array_value( $meta, 'sp_address', false );
 		if ( false !== $address ) {
-			$location = $address;
+			$location = $venue->name . '\, ' . escapeString($address);
 		}
 
 		// Generate geo tag
@@ -130,7 +136,8 @@ foreach ( $events as $event):
 	// Append to output string
 	$output .=
 	"BEGIN:VEVENT\n" .
-	"SUMMARY:" . $summary . "\n" .
+	"SUMMARY:" . escapeString($summary) . "\n" .
+	"DESCRIPTION:" . escapeString($event->post_content) . "\n" .
 	"UID:$event->ID\n" .
 	"STATUS:CONFIRMED\n" .
 	"DTSTART:" . mysql2date( $date_format, $event->post_date ) . "\n" .

--- a/feeds/ical.php
+++ b/feeds/ical.php
@@ -21,7 +21,6 @@ function escapeString($string) {
 
 // Get events in calendar
 $calendar = new SP_Calendar( $post );
-$postcontent = "$post->post_content";
 $events = $calendar->data();
 
 // Get blog locale


### PR DESCRIPTION
Made various enhancements/improvements to the iCal feed implementation. I have been testing and using these changes on TulsaRoustabouts.com for a few weeks without any issues and would love to share them with the greater SportsPress community. To see a feed currently using these changes, visit [this link](http://www.tulsaroustabouts.com/calendar/2016trfcfull?feed=sp-ical).

**Included commits:**
- Added new function to properly escape feed information that is not escaped [line 17]
- Added venue name to Address section [line 85]
- Added post content from events (currently only supports plain text data) to iCal item description [line 139]
- Fixed bug with iCal feed information not being properly escaped and thus losing any information after a non-escaped comma [lines 85, 138]

**Future ideas:**
- Customizable iCal event item duration length
- Rich text in iCal event descriptions