### PR TITLE
Removed hardcoded protocol for calls to google maps scripts

### DIFF
--- a/includes/admin/class-sp-admin-assets.php
+++ b/includes/admin/class-sp-admin-assets.php
@@ -86,7 +86,7 @@ class SP_Admin_Assets {
 
 		wp_register_script( 'jquery-fitvids', SP()->plugin_url() . '/assets/js/jquery.fitvids.js', array( 'jquery' ), '1.1', true );
 
-		wp_register_script( 'google-maps', 'http://maps.googleapis.com/maps/api/js?sensor=false&libraries=places' );
+		wp_register_script( 'google-maps', '//maps.googleapis.com/maps/api/js?sensor=false&libraries=places' );
 
 		wp_register_script( 'jquery-locationpicker', SP()->plugin_url() . '/assets/js/locationpicker.jquery.js', array( 'jquery', 'google-maps' ), '0.1.6', true );
 

--- a/includes/class-sp-frontend-scripts.php
+++ b/includes/class-sp-frontend-scripts.php
@@ -76,7 +76,7 @@ class SP_Frontend_Scripts {
 		wp_enqueue_script( 'sportspress', plugin_dir_url( SP_PLUGIN_FILE ) .'assets/js/sportspress.js', array( 'jquery' ), SP()->version, true );
 
 		if ( is_singular( 'sp_event' ) || is_tax( 'sp_venue' ) ):
-			wp_enqueue_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false', array(), '3.exp', true );
+			wp_enqueue_script( 'google-maps', '//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false', array(), '3.exp', true );
 			wp_enqueue_script( 'sp-maps', plugin_dir_url( SP_PLUGIN_FILE ) .'assets/js/sp-maps.js', array( 'jquery', 'google-maps' ), time(), true );
 			wp_localize_script( 'sp-maps', 'vars', array( 'map_type' => strtoupper( get_option( 'sportspress_map_type', 'ROADMAP' ) ), 'zoom' => get_option( 'sportspress_map_zoom', 15 ) ) );
 		endif;


### PR DESCRIPTION
We run the admin in https and having the link to google being in http, causes insecure content warning in google chrome which blocks the code from working.   Therefore the editing of venue is broken when using the admin in https.