### PR TITLE
override the global date in event-calendar.php template

### DIFF
--- a/templates/event-calendar.php
+++ b/templates/event-calendar.php
@@ -25,6 +25,7 @@ $defaults = array(
 	'initial' => true,
 	'caption_tag' => 'h4',
 	'show_all_events_link' => false,
+	'override_global_date' => false,
 );
 
 extract( $defaults, EXTR_SKIP );
@@ -48,6 +49,10 @@ if ( $team )
 	$calendar->team = $team;
 if ( $player )
 	$calendar->player = $player;
+if ($override_global_date) {
+	$year = gmdate('Y', current_time('timestamp'));
+	$monthnum = gmdate('m', current_time('timestamp'));
+}
 $events = $calendar->data();
 
 if ( empty( $events ) ) {


### PR DESCRIPTION
If the the event-calendar ist put on the sidebar and a blog post from the past is viewed then the event-calendar will always show the past month by using the global vars $monthnum and $year from url.
To avoid this it is useful to override this behavior to show always the current month and year