### PR TITLE
Avoid Fatal Errors when Core REST API classes don't exist.

### DIFF
--- a/includes/api/class-sp-rest-posts-controller.php
+++ b/includes/api/class-sp-rest-posts-controller.php
@@ -1,8 +1,10 @@
 <?php
 
-class SP_REST_Posts_Controller extends WP_REST_Posts_Controller {
-	public function __construct( $post_type ) {
-		parent::__construct( $post_type );
-		$this->namespace = 'sportspress/v2';
+if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
+	class SP_REST_Posts_Controller extends WP_REST_Posts_Controller {
+		public function __construct( $post_type ) {
+			parent::__construct( $post_type );
+			$this->namespace = 'sportspress/v2';
+		}
 	}
 }

--- a/includes/api/class-sp-rest-terms-controller.php
+++ b/includes/api/class-sp-rest-terms-controller.php
@@ -1,8 +1,10 @@
 <?php
 
-class SP_REST_Terms_Controller extends WP_REST_Terms_Controller {
-	public function __construct( $taxonomy ) {
-		parent::__construct( $taxonomy );
-		$this->namespace = 'sportspress/v2';
+if ( class_exists( 'WP_REST_Terms_Controller' ) ) {
+	class SP_REST_Terms_Controller extends WP_REST_Terms_Controller {
+		public function __construct( $taxonomy ) {
+			parent::__construct( $taxonomy );
+			$this->namespace = 'sportspress/v2';
+		}
 	}
 }


### PR DESCRIPTION
In some cases (like users running older versions of WordPress), classes like `WP_REST_Posts_Controller` may not exist, thus creating Fatal Errors.

Here is an example.
https://wordpress.org/support/topic/plugin-conflict-154/