### PR TITLE
Fix encoding error

### DIFF
--- a/includes/libraries/class-phpstack.php
+++ b/includes/libraries/class-phpstack.php
@@ -7,7 +7,7 @@
  * PHP functions `array_pop()`, `array_push()`, and `end()`
  *
  * @author Jon Lawrence <jlawrence11@gmail.com>
- * @copyright Copyright ©2005-2013 Jon Lawrence
+ * @copyright Copyright Â©2005-2013 Jon Lawrence
  * @license http://opensource.org/licenses/LGPL-2.1 LGPL 2.1 License
  * @package eos.class.php
  * @version 2.0


### PR DESCRIPTION
`class-phpstack.php` was saved with ISO-8859-1 encoding, whereas the rest of the project uses UTF-8 encoding. This commit converts `class-phpstack.php` from ISO-8859-1 to UTF-8