### PR TITLE
Event Player List Sorting Options

### DIFF
--- a/includes/admin/settings/class-sp-settings-events.php
+++ b/includes/admin/settings/class-sp-settings-events.php
@@ -273,6 +273,29 @@ class SP_Settings_Events extends SP_Settings_Page {
 			),
 
 			array(
+				array( 'title' => __( 'Players', 'sportspress' ), 'type' => 'title', 'desc' => '', 'id' => 'eventplayer_options' ),
+			),
+
+			apply_filters( 'sportspress_eventplayer_options', array(
+				array(
+					'title' 	=> __( 'Player Sorting', 'sportspress' ),
+					'id' 		=> 'sportspress_event_player_sort',
+					'default'	=> 'jersey',
+					'type' 		=> 'radio',
+					'options' => array(
+						'jersey'		=> __( 'Player Jersey (i.e. "33. John Doe")', 'sportspress' ),
+						'name'			=> __( 'Player Name (i.e. "John Doe")', 'sportspress' ),
+						'namejersey'	=> __( 'Player Name with Jersey (i.e. "John Doe (33)")', 'sportspress' ),
+					),
+				),
+
+			) ),
+
+			array(
+				array( 'type' => 'sectionend', 'id' => 'eventplayer_options' ),
+			),
+
+			array(
 				array( 'title' => __( 'Event Results', 'sportspress' ), 'type' => 'title', 'desc' => '', 'id' => 'result_options' ),
 			),
 

--- a/includes/sp-api-functions.php
+++ b/includes/sp-api-functions.php
@@ -354,6 +354,19 @@ function sp_get_player_name_with_number( $post = 0, $prepend = '', $append = '. 
 	}
 }
 
+function sp_get_player_name( $post = 0 ) {
+	return get_the_title( $post );
+}
+
+function sp_get_player_name_then_number( $post = 0, $prepend = ' (', $append = ')' ) {
+	$number = sp_get_player_number( $post );
+	if ( isset( $number ) && '' !== $number ) {
+		return get_the_title( $post ) . $prepend . $number . $append;
+	} else {
+		return get_the_title( $post );
+	}
+}
+
 function sp_player_details( $post = 0 ) {
 	sp_get_template( 'player-details.php', array( 'id' => $post ) );
 }

--- a/modules/sportspress-lazy-loading.php
+++ b/modules/sportspress-lazy-loading.php
@@ -137,11 +137,22 @@ class SportsPress_Lazy_Loading {
 			'orderby' => 'menu_order',
 		);
 
-		if ( 'sp_player' == $post_type ):
-			$args['meta_key'] = 'sp_number';
-			$args['orderby'] = 'meta_value_num';
-			$args['order'] = 'ASC';
-		endif;
+		$player_sort = get_option( 'sportspress_event_player_sort', 'jersey' );
+
+		if ( 'sp_player' == $post_type )
+		{
+			if( $player_sort == 'name' || $player_sort == 'namejersey' )
+			{
+				$args['order'] = 'ASC';
+				$args['orderby'] = 'title';
+			}
+			else
+			{
+				$args['meta_key'] = 'sp_number';
+				$args['orderby'] = 'meta_value_num';
+				$args['order'] = 'ASC';
+			}
+		}
 
 		$args['meta_query'] = array(
 			array(
@@ -198,7 +209,19 @@ class SportsPress_Lazy_Loading {
 						<li>
 							<label class="selectit">
 								<input type="checkbox" value="<?php echo $post->ID; ?>" name="<?php echo $slug; ?><?php if ( isset( $index ) ) echo '[' . $index . ']'; ?>[]" <?php checked( array_key_exists( $post->ID, $selected ) ); ?>>
-								<?php echo sp_get_player_name_with_number( $post->ID ); ?>
+								<?php
+									switch( $player_sort )
+									{
+									case 'name':
+										echo sp_get_player_name( $post->ID );
+										break;
+									case 'namejersey':
+										echo sp_get_player_name_then_number( $post->ID );
+										break;
+									default:  // 'jersey'
+										echo sp_get_player_name_with_number( $post->ID );
+									}
+								?>
 							</label>
 						</li>
 						<?php unset( $selected[ $post->ID ] ); ?>
@@ -208,7 +231,19 @@ class SportsPress_Lazy_Loading {
 						<li>
 							<label class="selectit">
 								<input type="checkbox" value="<?php echo $post_id; ?>" name="<?php echo $slug; ?><?php if ( isset( $index ) ) echo '[' . $index . ']'; ?>[]" <?php checked( true ); ?>>
-								<?php echo sp_get_player_name_with_number( $post_id ); ?>
+								<?php
+									switch( $player_sort )
+									{
+									case 'name':
+										echo sp_get_player_name( $post_id );
+										break;
+									case 'namejersey':
+										echo sp_get_player_name_then_number( $post_id );
+										break;
+									default:  // 'jersey'
+										echo sp_get_player_name_with_number( $post_id );
+									}
+								?>
 							</label>
 						</li>
 					<?php } } ?>


### PR DESCRIPTION
Added option to sort player list by name in addition to jersey number.

In our rec league, the jersey numbers change often (and randomly).  It is much quicker for scorekeepers to find names and enter stats if they are alphabetical by name.