### PR TITLE
Event Player Checklist Sort Options

### DIFF
--- a/includes/admin/settings/class-sp-settings-events.php
+++ b/includes/admin/settings/class-sp-settings-events.php
@@ -273,6 +273,31 @@ class SP_Settings_Events extends SP_Settings_Page {
 			),
 
 			array(
+				array( 'title' => __( 'Players', 'sportspress' ), 'type' => 'title', 'desc' => '', 'id' => 'eventplayer_options' ),
+			),
+
+			apply_filters( 'sportspress_eventplayer_options', array(
+				array(
+					'title' 	=> __( 'Player Sorting', 'sportspress' ),
+					'id' 		=> 'sportspress_event_player_sort',
+					'default'	=> 'jersey',
+					'type' 		=> 'radio',
+					'options' => array(
+						'jersey'=> __( 'Jersey (e.g. "33. John Doe")', 'sportspress' ),
+						'name'	=> __( 'Name (e.g. "John Doe (33)")', 'sportspress' ),
+					),
+					'desc_tip' 		=> _x( 'When editing an event, this determines how the checklist of players are sorted in the Teams metabox.  This does not affect the Box Score section.', 'event player sort setting description', 'sportspress' ),
+
+				),
+
+			) ),
+
+
+			array(
+				array( 'type' => 'sectionend', 'id' => 'eventplayer_options' ),
+			),
+
+			array(
 				array( 'title' => __( 'Event Results', 'sportspress' ), 'type' => 'title', 'desc' => '', 'id' => 'result_options' ),
 			),
 

--- a/includes/sp-api-functions.php
+++ b/includes/sp-api-functions.php
@@ -344,11 +344,25 @@ function sp_get_player_number( $post = 0 ) {
 	return get_post_meta( $post, 'sp_number', true );
 }
 
+function sp_get_player_name( $post = 0 ) {
+	return apply_filters( 'sportspress_player_name', get_the_title( $post ));
+}
+
 function sp_get_player_name_with_number( $post = 0, $prepend = '', $append = '. ' ) {
-	$name = apply_filters( 'sportspress_player_name', get_the_title( $post ));
+	$name = sp_get_player_name( $post );
 	$number = sp_get_player_number( $post );
 	if ( isset( $number ) && '' !== $number ) {
 		return apply_filters( 'sportspress_player_name_with_number', $prepend . $number . $append . $name);
+	} else {
+		return $name;
+	}
+}
+
+function sp_get_player_name_then_number( $post = 0, $prepend = ' (', $append = ')' ) {
+	$name = sp_get_player_name( $post );
+	$number = sp_get_player_number( $post );
+	if ( isset( $number ) && '' !== $number ) {
+		return apply_filters( 'sportspress_player_name_then_number', $name . $prepend . $number . $append);
 	} else {
 		return $name;
 	}

--- a/modules/sportspress-lazy-loading.php
+++ b/modules/sportspress-lazy-loading.php
@@ -137,11 +137,22 @@ class SportsPress_Lazy_Loading {
 			'orderby' => 'menu_order',
 		);
 
-		if ( 'sp_player' == $post_type ):
-			$args['meta_key'] = 'sp_number';
-			$args['orderby'] = 'meta_value_num';
-			$args['order'] = 'ASC';
-		endif;
+		$player_sort = get_option( 'sportspress_event_player_sort', 'jersey' );
+
+		if ( 'sp_player' == $post_type )
+		{
+			if( $player_sort == 'name' )
+			{
+				$args['order'] = 'ASC';
+				$args['orderby'] = 'title';
+			}
+			else // default 'jersey'
+			{
+				$args['meta_key'] = 'sp_number';
+				$args['orderby'] = 'meta_value_num';
+				$args['order'] = 'ASC';
+			}
+		}
 
 		$args['meta_query'] = array(
 			array(
@@ -198,7 +209,16 @@ class SportsPress_Lazy_Loading {
 						<li>
 							<label class="selectit">
 								<input type="checkbox" value="<?php echo $post->ID; ?>" name="<?php echo $slug; ?><?php if ( isset( $index ) ) echo '[' . $index . ']'; ?>[]" <?php checked( array_key_exists( $post->ID, $selected ) ); ?>>
-								<?php echo sp_get_player_name_with_number( $post->ID ); ?>
+								<?php
+									switch( $player_sort )
+									{
+									case 'name':
+										echo sp_get_player_name_then_number( $post->ID );
+										break;
+									default:  // 'jersey'
+										echo sp_get_player_name_with_number( $post->ID );
+									}
+								?>
 							</label>
 						</li>
 						<?php unset( $selected[ $post->ID ] ); ?>
@@ -208,7 +228,16 @@ class SportsPress_Lazy_Loading {
 						<li>
 							<label class="selectit">
 								<input type="checkbox" value="<?php echo $post_id; ?>" name="<?php echo $slug; ?><?php if ( isset( $index ) ) echo '[' . $index . ']'; ?>[]" <?php checked( true ); ?>>
-								<?php echo sp_get_player_name_with_number( $post_id ); ?>
+								<?php
+									switch( $player_sort )
+									{
+									case 'name':
+										echo sp_get_player_name_then_number( $post_id );
+										break;
+									default:  // 'jersey'
+										echo sp_get_player_name_with_number( $post_id );
+									}
+								?>
 							</label>
 						</li>
 					<?php } } ?>


### PR DESCRIPTION
Added option to sort list of players (on the Teams metabox of Events) by Name or Jersey (default).