### PR TITLE
Fix - Include staff name and profile in [staff] shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .htaccess
 *.log
 .DS_STORE
+.idea/

--- a/includes/shortcodes/class-sp-shortcode-staff.php
+++ b/includes/shortcodes/class-sp-shortcode-staff.php
@@ -19,7 +19,10 @@ class SP_Shortcode_Staff {
 		if ( ! isset( $atts['id'] ) && isset( $atts[0] ) && is_numeric( $atts[0] ) )
 			$atts['id'] = $atts[0];
 
-		sp_get_template( 'staff-photo.php', $atts );
+		sp_get_template( 'staff-header.php',  $atts );
+		sp_get_template( 'staff-photo.php',   $atts );
 		sp_get_template( 'staff-details.php', $atts );
+		sp_get_template( 'staff-excerpt.php', $atts );
+		sp_get_template( 'staff-content.php', $atts );
 	}
 }

--- a/templates/staff-content.php
+++ b/templates/staff-content.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Staff Content
+ *
+ * @author 		ThemeBoy
+ * @package 	SportsPress/Templates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( get_option( 'sportspress_staff_show_content', 'yes' ) === 'no' ) return;
+
+if ( ! isset( $id ) )
+    $id = get_the_ID();
+
+$post = get_post( $id );
+$content = $post->post_content;
+if ( $content ) {
+    ?>
+    <div class="sp-template sp-section-staff-content sp-template-content">
+        <div class="sp-content"><?php echo apply_filters( 'the_content', $content ); ?></div>
+    </div>
+    <?php
+}

--- a/templates/staff-excerpt.php
+++ b/templates/staff-excerpt.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Staff Excerpt
+ *
+ * @author 		ThemeBoy
+ * @package 	SportsPress/Templates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( get_option( 'sportspress_staff_show_excerpt', 'yes' ) === 'no' ) return;
+
+if ( ! isset( $id ) )
+    $id = get_the_ID();
+
+$post = get_post( $id );
+$excerpt = $post->post_excerpt;
+if ( $excerpt ) {
+    ?>
+    <div class="sp-template sp-section-staff-excerpt sp-template-excerpt">
+        <p class="sp-excerpt"><?php echo $excerpt; ?></p>
+    </div>
+    <?php
+}

--- a/templates/staff-header.php
+++ b/templates/staff-header.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Staff Header
+ *
+ * @author 		ThemeBoy
+ * @package 	SportsPress/Templates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! isset( $id ) )
+    $id = get_the_ID();
+
+$post = get_post( $id );
+$title = $post->post_title;
+if ( $title ) {
+
+    $staff = new SP_Staff( $id );
+    $role  = $staff->role();
+    if ( $role )
+        $title = '<strong class="sp-staff-role">' . $role->name . '</strong> ' . $title;
+
+    ?>
+    <div class="sp-template sp-template-staff-header sp-template-header">
+        <h3 class="sp-item-title"><?php echo $title ?></h3>
+    </div>
+    <?php
+}


### PR DESCRIPTION
Fix #179  - Make [staff] shortcode render the entire staff content including their name and profile (editor content).