### PR TITLE
Fix RTL CSS not working due to lower weight

### DIFF
--- a/assets/css/sportspress-rtl.css
+++ b/assets/css/sportspress-rtl.css
@@ -15,7 +15,7 @@
 
 /* Data Tables */
 .sp-data-table .data-name {
-	text-align: right;
+	text-align: right !important;
 }
 
 /* Pagination */


### PR DESCRIPTION
The RTL rule has no effect since [this rule in LTR](https://github.com/ThemeBoy/SportsPress/blob/742e3c9/assets/css/sportspress-style.css#L172-L174) takes precedence.

Related: Ticket [#15928](https://secure.helpscout.net/conversation/521620759/15928?folderId=287741)

