### PR TITLE
Add option to WPML config file

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,5 +1,6 @@
 <wpml-config>
   <admin-texts>
+    <key name="sportspress_footer_sponsors_title"></key>
     <key name="sportspress_text">
       <key name="Age"/>
       <key name="Article"/>


### PR DESCRIPTION
The option is `sportspress_footer_sponsors_title` and it appears in **Sportspress Settings > Settings**

There are other good candidates:

- Branding > Label
- League Menu > Title


Cheers,
Nabil

---

Reference: [Ticket #15893](https://secure.helpscout.net/conversation/520463000/15893?folderId=287736#thread-1420459816)
