### PR TITLE
Validate `sportspress_term_order()` parameter `$terms`

### DIFF
--- a/includes/sp-template-hooks.php
+++ b/includes/sp-template-hooks.php
@@ -141,6 +141,10 @@ function sportspress_strcmp_term_slug( $a, $b ) {
 
 function sportspress_term_order( $terms, $post_id, $taxonomy ) {
 
+	if ( ! is_array( $terms ) ) {
+		return [];
+	}
+
     if ( is_sp_taxonomy( $taxonomy ) ) {
     	uasort( $terms, 'sportspress_strcmp_term_slug' );
     }


### PR DESCRIPTION
$terms can be False or WP_Error, in which case, the function will produce warnings. e.g.:

`Warning: uasort() expects parameter 1 to be array, boolean given in /var/html/wp-content/plugins/sportspress-pro/includes/sportspress/includes/sp-template-hooks.php on line 145`