### PR TITLE
Prevent array_filter on non-array `$result`

### DIFF
--- a/includes/class-sp-event.php
+++ b/includes/class-sp-event.php
@@ -17,7 +17,7 @@ class SP_Event extends SP_Custom_Post{
 		$results = get_post_meta( $this->ID, 'sp_results', true );
 		if ( is_array( $results ) ) {
 			foreach( $results as $result ) {
-				$result = array_filter( $result );
+				$result = is_array( $result ) ? array_filter( $result ) : array();
 				if ( count( $result ) > 0 ) {
 					return 'results';
 				}


### PR DESCRIPTION
This fixes this recurring error: 

`Warning: array_filter() expects parameter 1 to be array, string given in /.../sportspress/includes/class-sp-event.php ... on line 20`