### PR TITLE
Preserve squad number "0" when importing players

### DIFF
--- a/includes/admin/importers/class-sp-player-importer.php
+++ b/includes/admin/importers/class-sp-player-importer.php
@@ -54,7 +54,7 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 			foreach ( $rows as $row ):
 
-				$row = array_filter( $row );
+				$row = array_filter( $row, 'strlen' );
 
 				if ( empty( $row ) ) continue;
 


### PR DESCRIPTION
The problem is that when you have a player with a squad number of "0" in your players CSV file, this player is imported without an empty squad number. This should fix it.