### PR TITLE
Make sure `wp_list_pluck()` is fed an array

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-sp-meta-box-staff-details.php
+++ b/includes/admin/post-types/meta-boxes/class-sp-meta-box-staff-details.php
@@ -49,7 +49,7 @@ class SP_Meta_Box_Staff_Details {
 		endif;
 
 		$roles = get_the_terms( $post->ID, 'sp_role' );
-		$role_ids = wp_list_pluck( $roles, 'term_id' );
+		$role_ids = is_array( $roles ) ? wp_list_pluck( $roles, 'term_id' ) : array();
 		
 		$teams = get_posts( array( 'post_type' => 'sp_team', 'posts_per_page' => -1 ) );
 		$past_teams = array_filter( get_post_meta( $post->ID, 'sp_past_team', false ) );


### PR DESCRIPTION
Hello,

This fixes this error:

` Warning: Invalid argument supplied for foreach() in /X/wp-includes/class-wp-list-util.php on line 148`

What happens is that [`wp_list_pluck()`](https://developer.wordpress.org/reference/functions/wp_list_pluck/) expects an array but is fed the result of [`get_terms()`](https://developer.wordpress.org/reference/functions/get_terms/) which is not sanitized, and `get_terms()` doesn't always return an array, sometimes it returns a boolean (`false`) and sometimes an object (`WP_Error` instance).