### PR TITLE
Fix PHP Warning (Illegal string offset 'outcome')

### DIFF
--- a/includes/class-sp-event.php
+++ b/includes/class-sp-event.php
@@ -629,6 +629,9 @@ class SP_Event extends SP_Custom_Post{
 				$outcomes = get_posts( $args );
 				foreach ( $meta as $team => $team_results ) {
 					if ( $outcomes ) {
+						if ( empty( $meta[ $team ] ) ) {
+							$meta[ $team ] = array();
+						}
 						$meta[ $team ][ 'outcome' ] = array();
 						foreach ( $outcomes as $outcome ) {
 							$meta[ $team ][ 'outcome' ][] = $outcome->post_name;


### PR DESCRIPTION
Fixes a nasty error, see https://secure.helpscout.net/conversation/565362747/16858/.