### PR TITLE
Add past teams correctly when importing players

### DIFF
--- a/includes/admin/importers/class-sp-player-importer.php
+++ b/includes/admin/importers/class-sp-player-importer.php
@@ -123,9 +123,11 @@ if ( class_exists( 'WP_Importer' ) ) {
 					// Add team to player
 					add_post_meta( $id, 'sp_team', $team_id );
 
-					// Update current team if first in array
+					// Update current team if first in array, otherwise use as past team
 					if ( $i == 0 ):
 						update_post_meta( $id, 'sp_current_team', $team_id );
+					else :
+						add_post_meta( $id, 'sp_past_team', $team_id );
 					endif;
 
 					$i++;


### PR DESCRIPTION
This fixes part of ticket 16802 where after and import, a player with multiple teams appears to having been imported correctly in the players listing page in the dashboard, but once you open the player page in the dashboard, the player's past teams field is empty. 