### PR TITLE
Improve stats visibility on the dashboard

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -322,6 +322,11 @@ table.widefat.sp-data-table input[type="number"] {
     padding: 3px 5px;
 }
 
+table.widefat.sp-data-table input[type="text"]::placeholder,
+table.widefat.sp-data-table input[type="number"]::placeholder {
+	color: silver;
+}
+
 table.widefat.sp-data-table input.small-text {
 	width: 50px;
 	min-width: 0;


### PR DESCRIPTION
Improve stats visibility on the dashboard by reducing the lightness on automatic stats (from `gray` to `silver`).