### PR TITLE
Fix PHP error

### DIFF
--- a/includes/class-sp-player-list.php
+++ b/includes/class-sp-player-list.php
@@ -529,6 +529,7 @@ class SP_Player_List extends SP_Secondary_Post {
 						if ( sizeof( $results ) ):
 							foreach ( $results as $id => $team_results ):
 								if ( $team_id == $id ) continue;
+								$team_results['outcome'] = null;
 								unset( $team_results['outcome'] );
 								foreach ( $team_results as $result_slug => $team_result ):
 


### PR DESCRIPTION
Fix PHP error `( ! ) Fatal error: Uncaught Error: Cannot unset string offsets in /var/www/public/wp-content/plugins/sportspress/includes/class-sp-player-list.php on line 532`