### PR TITLE
Fix team name in player list

### DIFF
--- a/templates/player-list.php
+++ b/templates/player-list.php
@@ -194,7 +194,7 @@ foreach ( $groups as $group ):
 		
 		if ( array_key_exists( 'team', $labels ) ):
 			$team = sp_array_value( $row, 'team', get_post_meta( $id, 'sp_current_team', true ) );
-			$team_name = sp_team_short_name( $team );
+			$team_name = $team ? sp_team_short_name( $team ) : '';
 			if ( $link_teams && false !== get_post_status( $team ) ):
 				$team_name = '<a href="' . get_post_permalink( $team ) . '">' . $team_name . '</a>';
 			endif;


### PR DESCRIPTION
When the player doesn't have a team, the player list shouldn't use the post title as the team name but should display nothing (empty string)