### PR TITLE
Do no filter relevant events

### DIFF
--- a/includes/class-sp-calendar.php
+++ b/includes/class-sp-calendar.php
@@ -426,7 +426,7 @@ class SP_Calendar extends SP_Secondary_Post {
 		if ( $this->teams_past ){
 			$events_past = array();
 			foreach ( $events as $single_event ) {
-				if ( get_post_meta( $single_event->ID,'sp_team' ) === $this->teams_past ){
+				if ( sort( get_post_meta( $single_event->ID, 'sp_team' ) )=== sort( $this->teams_past ) ) {
 					$events_past[] = $single_event;
 				}
 			}

--- a/includes/class-sp-calendar.php
+++ b/includes/class-sp-calendar.php
@@ -426,7 +426,7 @@ class SP_Calendar extends SP_Secondary_Post {
 		if ( $this->teams_past ){
 			$events_past = array();
 			foreach ( $events as $single_event ) {
-				if ( sort( get_post_meta( $single_event->ID, 'sp_team' ) )=== sort( $this->teams_past ) ) {
+				if ( sort( get_post_meta( $single_event->ID, 'sp_team' ) ) === sort( $this->teams_past ) ) {
 					$events_past[] = $single_event;
 				}
 			}


### PR DESCRIPTION
Prevent filtering events with same teams but in reverse order (like second legs).

See ticket 19598