### PR TITLE
Attach "chosen" to dropdowns correctly

### DIFF
--- a/assets/js/admin/sportspress-admin.js
+++ b/assets/js/admin/sportspress-admin.js
@@ -14,13 +14,16 @@ jQuery(document).ready(function($){
 	});
 
 	// Chosen select
-	$(".chosen-select").chosen({
-		allow_single_deselect: true,
-		search_contains: true,
-		single_backstroke_delete: false,
-		disable_search_threshold: 10,
-		placeholder_text_multiple: localized_strings.none
-	});
+	$(document).on("postbox-toggled", function() {
+		$(".chosen-select").filter(":visible").chosen({
+			allow_single_deselect: true,
+			search_contains: true,
+			single_backstroke_delete: false,
+			disable_search_threshold: 10,
+			placeholder_text_multiple: localized_strings.none
+		});
+	}).trigger("postbox-toggled");
+
 
 	// Auto key placeholder
 	$("#poststuff #title").on("keyup", function() {


### PR DESCRIPTION
This patch fixes the bug with "chosen"-enabled dropdowns.

### To reproduce
0. Open a player page in the dashboard
0. Close (collapse) the details metabox
0. Reload the page
0. Verify the dropdowns in the details metabox

### Bug
![screenshot_2019-02-25_16-25-52](https://user-images.githubusercontent.com/225615/53347776-b8d98080-3911-11e9-86be-acaf265e591b.png)
