### PR TITLE
Fix timezone handling in countdowns

### DIFF
--- a/assets/js/sportspress.js
+++ b/assets/js/sportspress.js
@@ -21,16 +21,9 @@ function sp_viewport() {
 		var countDownDate = new Date($(this).data('countdown')).getTime();
 		// Iterate every second
 		var x = setInterval(function() {
-			
-			// Get todays date and time
-			var now = new Date();
-			
-			// Convert curent date and time to UTC
-			var tzDifference = now.getTimezoneOffset();
-			var nowutc = new Date(now.getTime() + tzDifference * 60 * 1000);
-			
+
 			// Find the distance between now and the count down date
-			var distance = countDownDate - nowutc;
+			var distance = countDownDate - (new Date);
 			if ( distance < 0 ) {
 				distance = 0;
 			}


### PR DESCRIPTION
We don't need to worry about timezone, Date constructor is tricky, it does the conversions itself, the  conversion we need is already done in this line:

```
		var countDownDate = new Date($(this).data('countdown')).getTime();
```