### PR TITLE
The Metrics data are updatables by rest api

### DIFF
--- a/includes/api/class-sp-rest-api.php
+++ b/includes/api/class-sp-rest-api.php
@@ -430,7 +430,6 @@ class SP_REST_API {
 				'update_callback' => 'SP_REST_API::update_post_meta_array',
 				'schema'          => array(
 					'description'     => __( 'Metrics', 'sportspress' ),
-					'type'            => 'array',
 					'context'         => array( 'view', 'edit' ),
 					'arg_options'     => array(
 						'sanitize_callback' => 'rest_sanitize_request_arg',
@@ -564,6 +563,11 @@ class SP_REST_API {
 	 * @return bool|int
 	 */
 	public static function update_post_meta_array( $value, $object, $field_name ) {
+		// Convert PHP object to array
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+		}
+
 		if ( ! is_array( $value ) ) return false;
 		
 		$type = $object->post_type;

--- a/includes/class-sp-player.php
+++ b/includes/class-sp-player.php
@@ -96,7 +96,7 @@ class SP_Player extends SP_Custom_Post {
 			$metric = sp_array_value( $metrics, $key, null );
 			if ( $metric == null )
 				continue;
-			$data[ $value ] = sp_array_value( $metrics, $key, '&nbsp;' );
+			$data[ $key ] = sp_array_value( $metrics, $key, '&nbsp;' );
 		endforeach;
 		return $data;
 	}


### PR DESCRIPTION
To address #339

Remove array control on metrics data and add an autoconversion of PHP Object in PHP array.

For json request, i use the variable instead of label in metrics.

The variable names are lower case, without accent, without space (more stable than a label in a site).