### PR TITLE
Fix HTML for staff in event performance table

### DIFF
--- a/templates/event-performance-table.php
+++ b/templates/event-performance-table.php
@@ -68,8 +68,8 @@ $i = 0;
 					foreach ( $subs as $sub_id => $sub ):
 						if ( ! $sub_id )
 							continue;
-						$index = sp_array_value( $sub, 'sub', 0 );
-						$lineup_sub_relation[ $index ] = $sub_id;
+						$i = sp_array_value( $sub, 'sub', 0 );
+						$lineup_sub_relation[ $i ] = $sub_id;
 					endforeach;
 
 					$data = apply_filters( 'sportspress_event_performance_players', $data, $lineups, $subs, $mode );
@@ -274,7 +274,11 @@ $i = 0;
 				</<?php echo ( $show_players ? 'tfoot' : 'tbody' ); ?>>
 			<?php endif; ?>
 		</table>
+		<?php
+			if ( $show_staff ) {
+				echo sp_get_template( 'event-staff.php', array( 'id' => $id, 'index' => $index ) );
+			}
+		?>
 	</div>
-	
 	<?php do_action( 'sportspress_after_event_performance_table', $data, $lineups, $subs, $class ); ?>
 </div>

--- a/templates/event-performance.php
+++ b/templates/event-performance.php
@@ -236,6 +236,7 @@ if ( is_array( $teams ) ):
 								'performance_ids' => isset( $performance_ids ) ? $performance_ids : null,
 								'primary' => 'primary' == $total ? $primary : null,
 								'class' => 'sp-template-event-performance-team-' . $index . ' sp-template-event-performance-section sp-template-event-performance-section-' . $section_id . ' sp-template-event-performance-team-' . $index . '-section-' . $section_id,
+								'show_staff' => $show_staff,
 							) );
 						}
 						
@@ -256,9 +257,12 @@ if ( is_array( $teams ) ):
 					}
 					
 					sp_get_template( 'event-performance-table.php', array(
+						'id' => $id,
+						'index' => $index,
 						'scrollable' => $scrollable,
 						'sortable' => $sortable,
 						'show_players' => $show_team_players,
+						'show_staff' => $show_staff,
 						'show_numbers' => $show_numbers,
 						'show_minutes' => $show_minutes,
 						'show_total' => $show_total,
@@ -272,14 +276,9 @@ if ( is_array( $teams ) ):
 						'link_posts' => $link_posts,
 						'performance_ids' => isset( $performance_ids ) ? $performance_ids : null,
 						'primary' => 'primary' == $total ? $primary : null,
-
 					) );
 				}
 			}
-		
-			if ( $show_staff ):
-				sp_get_template( 'event-staff.php', array( 'id' => $id, 'index' => $index ) );
-			endif;
 		}
 		?>
 		<?php


### PR DESCRIPTION
The staff table was added outside of the floating div(s), which breaks the output.

[Before](https://i.imgur.com/VVhKSNd.png) | [After](https://i.imgur.com/I0UWvSN.png).