### PR TITLE
Set cricket runs as default in results

### DIFF
--- a/presets/team-sports/cricket.json
+++ b/presets/team-sports/cricket.json
@@ -12,10 +12,10 @@
 						"No Result"
 	],
 	"results": [
-						{ "name" : "Runs", "equation" : "$runs", "description" : "Runs", "primary" : 1 },
 						{ "name" : "Wickets Lost", "description" : "Wickets lost" },
 						{ "name" : "Overs", "equation" : "$o", "description" : "Overs" },
-						{ "name" : "BP", "description" : "Bonus points"}
+						{ "name" : "BP", "description" : "Bonus points"},
+						{ "name" : "Runs", "equation" : "$runs", "description" : "Runs", "primary" : 1 }
 	],
 	"performance": [
 						{ "name" : "&nbsp;", "id" : "notes", "section" : 0, "format" : "text", "description" : "Notes" },


### PR DESCRIPTION
It seems that SportsPress uses the last element on the JSON table as the default results, for cricket, the default now is BP, which seems wrong, see ticket 22247.