### PR TITLE
Fix event lists ignoring the `format` parameter

### DIFF
--- a/templates/event-list.php
+++ b/templates/event-list.php
@@ -51,7 +51,7 @@ extract( $defaults, EXTR_SKIP );
 $calendar = new SP_Calendar( $id );
 if ( $status != 'default' )
 	$calendar->status = $status;
-if ( $format != 'default' )
+if ( $format != 'all' )
 	$calendar->event_format = $format;
 if ( $date != 'default' )
 	$calendar->date = $date;


### PR DESCRIPTION
How to reproduce error:

- Create a few events with different formats (competitive, tournament and friendly)
- Create a calendar and set the format filter to anything but "All"
- Notice that the filter is ignored and events of different formats are displayed 

Related ticket: 22358