### PR TITLE
Remove deprecated jQuery method `size()`

### DIFF
--- a/assets/js/sportspress.js
+++ b/assets/js/sportspress.js
@@ -10,7 +10,7 @@ function sp_viewport() {
 (function($) {
 
 	/* Header */
-	if ( ! $('.sp-header').size() ) {
+	if ( ! $('.sp-header').length ) {
 		$('body').prepend( '<div class="sp-header sp-header-loaded"></div>' );
 	}
 


### PR DESCRIPTION
> The `.size()` method is deprecated as of jQuery 1.8. Use the `.length` property instead.
> 
> The `.size()` method is functionally equivalent to the `.length` property; however, **the `.length` property is preferred** because it does not have the overhead of a function call.

-- https://api.jquery.com/size/