### PR TITLE
Fix `.sp-data-table` tables width

### DIFF
--- a/assets/css/sportspress.css
+++ b/assets/css/sportspress.css
@@ -104,6 +104,7 @@
 .sp-data-table thead .sorting_asc_disabled,
 .sp-data-table thead .sorting_desc_disabled {
 	cursor: pointer;
+	position: relative;
 }
 .sp-data-table tbody a {
 	text-decoration: none;
@@ -112,6 +113,7 @@
 .sp-data-table .sorting_asc:after,
 .sp-data-table .sorting_desc:after {
 	font-family: dashicons;
+	margin: 0 -.2em;
 }
 .sp-data-table .sorting:after {
 	content: "\f156";


### PR DESCRIPTION
This fixes the error shown in the image. What happens is that the page width goes over the available screen width when the page contains a large SportsPress table.

I've seen this bug a lot and was finally able to find the cause...and the solution.

![](http://i.imgur.com/1k0kG4Y.png)