### PR TITLE
Use generted instead of hardcoded event formats

### DIFF
--- a/includes/admin/importers/class-sp-event-importer.php
+++ b/includes/admin/importers/class-sp-event-importer.php
@@ -472,8 +472,13 @@ if ( class_exists( 'WP_Importer' ) ) {
 						<td class="forminp forminp-radio" id="sp_formatdiv">
 							<fieldset id="post-formats-select">
 								<ul>
-									<li><input type="radio" name="sp_format" class="post-format" id="post-format-league" value="league" checked="checked"> <label for="post-format-league" class="post-format-icon post-format-league"><?php _e( 'Competitive', 'sportspress' ); ?></label></li>
-									<li><input type="radio" name="sp_format" class="post-format" id="post-format-friendly" value="friendly"> <label for="post-format-friendly" class="post-format-icon post-format-friendly"><?php _e( 'Friendly', 'sportspress' ); ?></label></li>
+									<?php
+										foreach( (new SP_Formats)->event as $name => $title ) {
+											?>
+											<li><input type="radio" name="sp_format" class="post-format" id="post-format-<?php echo $name; ?>" value="<?php echo $name; ?>" checked="checked"> <label for="post-format-<?php echo $name; ?>" class="post-format-icon post-format-<?php echo $name; ?>"><?php echo $title; ?></label></li>
+											<?php
+										}
+									?>
 								<br>
 							</fieldset>
 						</td>


### PR DESCRIPTION
Using generated event formats (i.e. `(new SP_Formats)->event`) instead of hard-coded ones allows the inclusion of custom formats added with [the `sportspress_formats` filter](https://github.com/ThemeBoy/SportsPress/blob/51e5ba02b25542a0a8bde497a05a80e9e2e5e9a9/includes/class-sp-formats.php#L25). 

Related ticket: 23122

![](http://i.imgur.com/MzspiGi.png)

