### PR TITLE
Fix multiple linked venues separator in team details

### DIFF
--- a/templates/team-details.php
+++ b/templates/team-details.php
@@ -36,7 +36,7 @@ endif;
 $terms = get_the_terms( $id, 'sp_venue' );
 if ( $terms ):
 	if ( get_option( 'sportspress_team_link_venues', 'no' ) === 'yes' ):
-		$data[ __( 'Home', 'sportspress' ) ] = get_the_term_list( $id, 'sp_venue' );
+		$data[ __( 'Home', 'sportspress' ) ] = get_the_term_list( $id, 'sp_venue', '', ', ' );
 	else:
 		$venues = array();
 		foreach ( $terms as $term ):


### PR DESCRIPTION
This image shows the error:

![](http://i.imgur.com/lnPNbGv.png)

Props to Stefan on ticket 23127.