### PR TITLE
Fix Elementor compatibility

### DIFF
--- a/assets/js/admin/editor.js
+++ b/assets/js/admin/editor.js
@@ -11,7 +11,7 @@
 			var p = g.split("[");
 			var label = p.shift();
 			var variations = p.shift();
-			var shortcodes = variations.split("|");
+			var shortcodes = typeof variations!== 'undefined' ? variations.split("|") : [];
 			var submenu = new Array();
 			shortcodes.forEach(function(s) {
 				submenu.push({


### PR DESCRIPTION
On default WP theme 2020 I have sp_shortcodes_button error  https://1ce.org/1#HC5UJNmxN
Page builder https://wordpress.org/plugins/elementor/
Discuss: https://wordpress.org/support/topic/sp_shortcodes_button-error/#post-12944559