### PR TITLE
Fix player league stats when not using "combined"

### DIFF
--- a/includes/class-sp-player.php
+++ b/includes/class-sp-player.php
@@ -335,13 +335,6 @@ class SP_Player extends SP_Custom_Post {
 					'relation' => 'AND',
 				),
 			);
-			
-			if ( -1 !== $section ):
-				$args['meta_query'][] = array(
-					'key' => ( 1 === $section ? 'sp_defense' : 'sp_offense' ),
-					'value' => $this->ID
-				);
-			endif;
 
 			if ( $league_id ):
 				$args['tax_query'][] = array(


### PR DESCRIPTION
When using `Offense → Defense` or `Defense → Offense` in `Settings > Players > Statistics > Categories`,  all stats are zeroed out. This chunk of code seems to be the cause. See the private ticket number 25434. 