### PR TITLE
format added for REST API and sp_events

### DIFF
--- a/includes/api/class-sp-rest-api.php
+++ b/includes/api/class-sp-rest-api.php
@@ -135,6 +135,23 @@ class SP_REST_API {
 				),
 			)
 		);
+
+		register_rest_field( 'sp_event',
+			'format',
+			array(
+				'get_callback'    => 'SP_REST_API::get_post_data',
+				'update_callback' => 'SP_REST_API::update_post_meta',
+				'schema'          => array(
+					'description'     => __( 'Format', 'sportspress' ),
+					'type'            => 'string',
+					'enum'            => array('league', 'friendly', 'tournament'),
+					'context'         => array( 'view', 'edit', 'embed' ),
+					'arg_options'     => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
 		
 		register_rest_field( 'sp_event',
 			'minutes',

--- a/includes/class-sp-event.php
+++ b/includes/class-sp-event.php
@@ -29,7 +29,12 @@ class SP_Event extends SP_Custom_Post{
 	public function day() {
 		$day = get_post_meta( $this->ID, 'sp_day', true );
 		return $day;
-  }
+	}
+	
+	public function format() {
+		$format = get_post_meta( $this->ID, 'sp_format', true );
+		return $format;
+	}
 	
 	public function minutes() {
 		$minutes = get_post_meta( $this->ID, 'sp_minutes', true );


### PR DESCRIPTION
I created an issue on wordpress support forum: https://wordpress.org/support/topic/rest-api-new-events-not-updated-in-league-table/
a while ago, now here comes the pull request.