### PR TITLE
Allow passing teams_past to calendar shortcodes

### DIFF
--- a/includes/class-sp-calendar.php
+++ b/includes/class-sp-calendar.php
@@ -285,6 +285,10 @@ class SP_Calendar extends SP_Secondary_Post {
 
 		// If we are showing past meetings filter by team's id and current event date
 		if ( $this->teams_past ):
+			$this->date_before = 'now'; 
+			if ( ! is_array( $this->teams_past ) ) {
+				$this->teams_past = explode( ',', $this->teams_past );
+			}
 			foreach ( $this->teams_past as $team_past ):
 				$args['meta_query'][] = array(
 					'key' => 'sp_team',


### PR DESCRIPTION
Example: `[event_blocks teams_past=36,38]`