### PR TITLE
Add Datatable string `emptyTable` to `localized_strings`

### DIFF
--- a/assets/js/sportspress.js
+++ b/assets/js/sportspress.js
@@ -100,6 +100,7 @@ function sp_viewport() {
 				"pageLength": display_length,
 				"ordering": sortable,
 			    "language": {
+			      "emptyTable": localized_strings.emptyTable,
 			      "aria": {
 			        "sortAscending": "",
 			        "sortDescending": ""

--- a/includes/class-sp-frontend-scripts.php
+++ b/includes/class-sp-frontend-scripts.php
@@ -75,7 +75,15 @@ class SP_Frontend_Scripts {
 		wp_enqueue_script( 'sportspress', plugin_dir_url( SP_PLUGIN_FILE ) .'assets/js/sportspress.js', array( 'jquery' ), SP()->version, true );
 
 		// Localize scripts
-		wp_localize_script( 'sportspress', 'localized_strings', array( 'days' => __( 'days', 'sportspress' ), 'hrs' => __( 'hrs', 'sportspress' ), 'mins' => __( 'mins', 'sportspress' ), 'secs' => __( 'secs', 'sportspress' ), 'previous' => __( 'Previous', 'sportspress' ), 'next' => __( 'Next', 'sportspress' ) ) );
+		wp_localize_script( 'sportspress', 'localized_strings', array(
+			'days' => __( 'days', 'sportspress' ),
+			'hrs' => __( 'hrs', 'sportspress' ),
+			'mins' => __( 'mins', 'sportspress' ),
+			'secs' => __( 'secs', 'sportspress' ),
+			'previous' => __( 'Previous', 'sportspress' ),
+			'next' => __( 'Next', 'sportspress' ),
+			'emptyTable' => __( 'No matching records found', 'sportspress' ),
+		) );
 
 		// Theme styles
 		$theme = wp_get_theme();


### PR DESCRIPTION
This allows us to customize the text shown when the table is empty:

![](https://imgur.com/s5L1wfj.png)

Here's the PHP code for overriding that text assuming this pull request is merged.

```php
 /**
  * Override some SportsPress translations
  *
  * - 'No matching records found' => 'Schedules Will Be Uploaded Shortly'
  */
add_filter( 'gettext', function( $translation, $text, $domain ) {
	$overrides = [
		'No matching records found' => 'Schedules Will Be Uploaded Shortly',
	];

	/**
	 * Should we override?
	 *
	 * - Domain is SportsPress
	 * - Locale is en_US
	 * - String is in the overrides table
	 */
	$should_override = ( true
		&& 'sportspress' === $domain
		&& 'en_US' ===  get_locale()
		&& array_key_exists( $text, $overrides )
	);

	return $should_override
		? $overrides[ $text ]
		: $translation
	;
}, 10, 3 );
``` 