### PR TITLE
Feature: Allow filtering for multiple leagues

### DIFF
--- a/includes/class-sp-calendar.php
+++ b/includes/class-sp-calendar.php
@@ -270,7 +270,11 @@ class SP_Calendar extends SP_Secondary_Post {
 		endif;
 
 		if ( $this->league ) :
-			$league_ids = array( $this->league );
+			if (is_array( $this->league )) {
+				$league_ids = $this->league;
+			} else {
+				$league_ids = array( $this->league );
+			}
 		endif;
 
 		if ( $this->season ) :


### PR DESCRIPTION
Within my custom theme, I would like to be able to get data from the calendar for one, or multiple leagues.
At the Moment this is not possible due to the fact that the handled `$this->league` variable, **always** gets casted into an array.

To be able to handle one or multiple values, I would like to add a check if the handed in data is already an array, or not.

This might also be useful for seasons and venues, but is currently outside of the scope of my project. 