### PR TITLE
Feature: Custom osm URL and attribution

### DIFF
--- a/assets/js/admin/sp-geocoder.js
+++ b/assets/js/admin/sp-geocoder.js
@@ -16,9 +16,9 @@ var map      = L.map( 'sp-location-picker' ).setView( [latitude, longitude], 15 
 	marker = L.marker( [latitude, longitude],{draggable: true, autoPan: true} ).addTo( map );
 
 L.tileLayer(
-	'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+	sp_osm_settings["tile_server"],
 	{
-		attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+		attribution: sp_osm_settings["attribution"]
 	}
 ).addTo( map );
 

--- a/includes/admin/settings/class-sp-settings-general.php
+++ b/includes/admin/settings/class-sp-settings-general.php
@@ -247,6 +247,42 @@ if ( ! class_exists( 'SP_Settings_General' ) ) :
 				);
 			}
 
+			$options = array_merge(
+				$options,
+				array(
+					array(
+						'type' => 'sectionend',
+						'id'   => 'general_options',
+					),
+					array(
+						'title' => esc_attr__( 'OpenStreetMap', 'sportspress' ),
+						'type'  => 'title',
+						'desc'  => '',
+						'id'    => 'osm_options',
+					),
+					array(
+						'title' => esc_attr__( 'Tile server', 'sportspress' ),
+						'id'    => 'sportspress_osm_tile_server',
+						'placeholder' => 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+						'css'   => 'width:100%;',
+						'type'  => 'text',
+						'desc' => esc_attr__('Leave empty to use the default', 'sportspress'),
+					),
+					array(
+						'title' => esc_attr__( 'Attributions', 'sportspress' ),
+						'id'    => 'sportspress_osm_attribution',
+						'placeholder' => 'Map data &amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/&quot;&gt;OpenStreetMap&lt;/a&gt; contributors',
+						'css'   => 'width:100%;',
+						'type'  => 'text',
+						'desc' => esc_attr__('Leave empty to use the default', 'sportspress'),
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'general_options',
+					),
+				)
+			  );
+
 			$settings = array_merge(
 				$settings,
 				apply_filters( 'sportspress_script_styling_options', $options ),

--- a/modules/sportspress-openstreetmap.php
+++ b/modules/sportspress-openstreetmap.php
@@ -70,7 +70,25 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 		 * Enqueue admin venue scripts
 		 */
 		public function admin_venue_scripts() {
-			  $screen = get_current_screen();
+			$screen = get_current_screen();
+
+			$maptype   = get_option( 'sportspress_map_type', 'roadmap' );
+			$maptype   = strtolower( $maptype );
+			$osm_tile  = get_option( 'sportspress_osm_tile_server', '' );
+			$osm_tile  = strtolower( $osm_tile );
+			$osm_tile  = empty( $osm_tile ) ? 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' : $osm_tile;
+			$osm_attribution  = get_option( 'sportspress_osm_attribution', '' );
+			$osm_attribution  = empty( $osm_attribution ) ? 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors' : $osm_attribution;
+			if ( 'satellite' === $maptype ) {
+				$osm_tile = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+				$osm_attribution = 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';
+			}
+			$osm_config = [
+				'tile_server' => $osm_tile,
+				'attribution' => $osm_attribution,
+			];
+
+
 
 			if ( in_array( $screen->id, sp_get_screen_ids() ) ) {
 				wp_enqueue_style( 'leaflet_stylesheet', SP()->plugin_url() . '/assets/css/leaflet.css', array(), '1.8.0' );
@@ -81,6 +99,7 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 				wp_register_script( 'leaflet_js', SP()->plugin_url() . '/assets/js/leaflet.js', array(), '1.8.0' );
 				wp_register_script( 'control-geocoder', SP()->plugin_url() . '/assets/js/Control.Geocoder.min.js', array( 'leaflet_js' ), '1.13.0' );
 				wp_register_script( 'sportspress-admin-geocoder', SP()->plugin_url() . '/assets/js/admin/sp-geocoder.js', array( 'leaflet_js', 'control-geocoder' ), SP_VERSION, true );
+				wp_localize_script( 'sportspress-admin-geocoder', 'sp_osm_settings', $osm_config );
 			}
 
 			if ( in_array( $screen->id, array( 'edit-sp_venue' ) ) ) {

--- a/modules/sportspress-openstreetmap.php
+++ b/modules/sportspress-openstreetmap.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 			add_action( 'sp_admin_venue_scripts', array( $this, 'admin_venue_scripts' ) );
 			add_action( 'sp_frontend_venue_scripts', array( $this, 'frontend_venue_scripts' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
-			add_action( 'sp_venue_show_map', array( $this, 'show_venue_map' ), 10, 5 );
+			add_action( 'sp_venue_show_map', array( $this, 'show_venue_map' ), 10, 7 );
 			add_action( 'sp_admin_geocoder_scripts', array( $this, 'admin_geocoder_scripts' ), 10 );
 			add_action( 'sp_setup_geocoder_scripts', array( $this, 'setup_geocoder_scripts' ), 10 );
 			add_action( 'sp_setup_venue_geocoder_scripts', array( $this, 'setup_venue_geocoder_scripts' ), 10 );
@@ -113,7 +113,7 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 		 *
 		 * @return mix
 		 */
-		public function show_venue_map( $latitude, $longitude, $address, $zoom, $maptype ) {
+		public function show_venue_map( $latitude, $longitude, $address, $zoom, $maptype, $osm_tile, $osm_attribution ) {
 			  $lat     = abs( $latitude );
 			  $lat_deg = floor( $lat );
 			  $lat_sec = ( $lat - $lat_deg ) * 3600;
@@ -142,8 +142,8 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 		  maxZoom: 18,
 		}).addTo(map);
 	<?php } else { ?>
-		L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-		  attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+  L.tileLayer('<?php echo htmlspecialchars($osm_tile); ?>', {
+  attribution: '<?php echo $osm_attribution ?>',
 		  maxZoom: 18,
 		}).addTo(map);
 	<?php } ?>

--- a/modules/sportspress-openstreetmap.php
+++ b/modules/sportspress-openstreetmap.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 			add_action( 'sp_admin_venue_scripts', array( $this, 'admin_venue_scripts' ) );
 			add_action( 'sp_frontend_venue_scripts', array( $this, 'frontend_venue_scripts' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'frontend_scripts' ) );
-			add_action( 'sp_venue_show_map', array( $this, 'show_venue_map' ), 10, 7 );
+			add_action( 'sp_venue_show_map', array( $this, 'show_venue_map' ), 10, 6 );
 			add_action( 'sp_admin_geocoder_scripts', array( $this, 'admin_geocoder_scripts' ), 10 );
 			add_action( 'sp_setup_geocoder_scripts', array( $this, 'setup_geocoder_scripts' ), 10 );
 			add_action( 'sp_setup_venue_geocoder_scripts', array( $this, 'setup_venue_geocoder_scripts' ), 10 );
@@ -113,7 +113,7 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 		 *
 		 * @return mix
 		 */
-		public function show_venue_map( $latitude, $longitude, $address, $zoom, $maptype, $osm_tile, $osm_attribution ) {
+		public function show_venue_map( $latitude, $longitude, $address, $zoom, $osm_tile, $osm_attribution ) {
 			  $lat     = abs( $latitude );
 			  $lat_deg = floor( $lat );
 			  $lat_sec = ( $lat - $lat_deg ) * 3600;
@@ -136,17 +136,10 @@ if ( ! class_exists( 'SportsPress_OpenStreetMap' ) ) :
 	// initialize map
 	map = L.map('sp_openstreetmaps_container', { zoomControl:false }).setView([lat, lon], <?php echo esc_attr( $zoom ); ?>);
 	// set map tiles source
-			  <?php if ( 'satellite' === $maptype ) { ?>
-		L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-		  attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
-		  maxZoom: 18,
-		}).addTo(map);
-	<?php } else { ?>
   L.tileLayer('<?php echo htmlspecialchars($osm_tile); ?>', {
   attribution: '<?php echo $osm_attribution ?>',
 		  maxZoom: 18,
 		}).addTo(map);
-	<?php } ?>
 	// add marker to the map
 	marker = L.marker([lat, lon]).addTo(map);
 	map.dragging.disable();

--- a/templates/venue-map.php
+++ b/templates/venue-map.php
@@ -35,13 +35,14 @@ $osm_attribution  = empty( $osm_attribution ) ? 'Map data &copy; <a href="https:
 if ( '' === $address ) {
 	$address = '+';
 }
-if ( 'satellite' !== $maptype ) {
-	$maptype = 'roadmap';
+if ( 'satellite' === $maptype ) {
+	$osm_tile = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+	$osm_attribution = 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';
 }
 
 
 if ( $latitude != null && $longitude != null ) {
-	do_action( 'sp_venue_show_map', $latitude, $longitude, $address, $zoom, $maptype, $osm_tile, $osm_attribution );
+	do_action( 'sp_venue_show_map', $latitude, $longitude, $address, $zoom, $osm_tile, $osm_attribution );
 }
 if ( is_tax( 'sp_venue' ) ) {
 	do_action( 'sportspress_after_venue_map' );

--- a/templates/venue-map.php
+++ b/templates/venue-map.php
@@ -26,6 +26,11 @@ $longitude = sp_array_value( $meta, 'sp_longitude', null );
 $zoom      = get_option( 'sportspress_map_zoom', 15 );
 $maptype   = get_option( 'sportspress_map_type', 'roadmap' );
 $maptype   = strtolower( $maptype );
+$osm_tile  = get_option( 'sportspress_osm_tile_server', '' );
+$osm_tile  = strtolower( $osm_tile );
+$osm_tile  = empty( $osm_tile ) ? 'https://tile.openstreetmap.org/{z}/{x}/{y}.png' : $osm_tile;
+$osm_attribution  = get_option( 'sportspress_osm_attribution', '' );
+$osm_attribution  = empty( $osm_attribution ) ? 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors' : $osm_attribution;
 
 if ( '' === $address ) {
 	$address = '+';
@@ -34,8 +39,9 @@ if ( 'satellite' !== $maptype ) {
 	$maptype = 'roadmap';
 }
 
+
 if ( $latitude != null && $longitude != null ) {
-	do_action( 'sp_venue_show_map', $latitude, $longitude, $address, $zoom, $maptype );
+	do_action( 'sp_venue_show_map', $latitude, $longitude, $address, $zoom, $maptype, $osm_tile, $osm_attribution );
 }
 if ( is_tax( 'sp_venue' ) ) {
 	do_action( 'sportspress_after_venue_map' );


### PR DESCRIPTION
Regarding privacy legislation in Europe (GDPR) using a custom OSM tile server may be desirable for some website operators. Privacy however, is not the only reason to use a custom tile server. Some users may simply be interested in a different looking map which can also be achieved using this setting.