### PR TITLE
Possible fix for blank pages with cache plugins

### DIFF
--- a/includes/class-sp-post-types.php
+++ b/includes/class-sp-post-types.php
@@ -23,7 +23,7 @@ class SP_Post_types {
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
 		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 10 );
 		add_action( 'trashed_post', array( $this, 'delete_config_post' ) );
-		add_filter( 'the_posts', array( $this, 'display_scheduled_events' ) );
+		add_filter( 'get_post_status', array( $this, 'display_scheduled_events' ), 10, 2 );
 	}
 
 	/**
@@ -606,13 +606,13 @@ class SP_Post_types {
 		}
 	}
 
-	public function display_scheduled_events( $posts ) {
-		global $wp_query, $wpdb;
-		if ( is_single() && $wp_query->post_count == 0 && isset( $wp_query->query_vars['sp_event'] ) ) {
-			$posts = $wpdb->get_results( $wp_query->request );
+	public function display_scheduled_events( $post_status, $post ) {
+		if ($post->post_type == 'sp_event' && $post_status == 'future') {
+			return "publish";
 		}
-		return $posts;
+		return $post_status;
 	}
+	
 }
 
 new SP_Post_types();


### PR DESCRIPTION
When a website uses a cache plugin like litespeed or memcache, the scheduled events pages didnt work. This is a possible fix.

https://wordpress.org/support/topic/match-overview-is-not-display/ 
https://wordpress.org/support/topic/sportspress-event-page-not-working-with-litespeed-cache-plugin/
https://wordpress.org/support/topic/all-sport-events-matches-showing-as-uncategorised/ https://wordpress.org/support/topic/sportspress-event-content-not-displaying/