### PR TITLE
Fix fatal error due to wrong type

### DIFF
--- a/includes/class-sp-league-table.php
+++ b/includes/class-sp-league-table.php
@@ -361,10 +361,9 @@ class SP_League_Table extends SP_Secondary_Post {
 			}
 
 			$results = (array) get_post_meta( $event->ID, 'sp_results', true );
-			$minutes = get_post_meta( $event->ID, 'sp_minutes', true );
-			if ( $minutes === '' ) {
-				$minutes = get_option( 'sportspress_event_minutes', 90 );
-			}
+
+			$minutes = (int) get_post_meta( $event->ID, 'sp_minutes', true );
+			$minutes = $minutes ? $minutes : (int) get_option( 'sportspress_event_minutes', 90 );
 
 			$i = 0;
 


### PR DESCRIPTION
The error is:

```
Fatal error: Uncaught Error: Unsupported operand types: int + string
in /var/www/wp-content/plugins/sportspress-pro/includes/sportspress/includes/class-sp-league-table.php on line 396
```