### PR TITLE
Update countdown.php

### DIFF
--- a/templates/countdown.php
+++ b/templates/countdown.php
@@ -99,9 +99,16 @@ else :
 	 * Exclude postponed or cancelled events.
 	 */
 	$args['meta_query'][] = array(
-		'key'     => 'sp_status',
-		'compare' => 'NOT IN',
-		'value'   => $excluded_statuses,
+		'relation' => 'OR',
+		array(
+			'key'     => 'sp_status',
+			'compare' => 'NOT IN',
+			'value'   => $excluded_statuses,
+		),
+		array(
+			'key'     => 'sp_status',
+			'compare' => 'NOT EXISTS',
+		),
 	);
 
 	$post = sp_get_next_event( $args );


### PR DESCRIPTION
Sometimes, maybe after a CSV import or API REST event creation, events are created with `sp_status` metadata. This fix makes sure these events are not excluded from countdowns.