### PR TITLE
When an image was used as performance icon, the output was not correct

### DIFF
--- a/modules/sportspress-icons.php
+++ b/modules/sportspress-icons.php
@@ -149,6 +149,20 @@ if ( ! class_exists( 'SportsPress_Icons' ) ) :
 				} else {
 					$icons = str_repeat( '<i class="sp-icon-' . $icon . '" title="' . $title . '" style="color:' . $color . ' !important"></i> ', intval( $value ) );
 				}
+			}else{
+				// Check if the performance has a thumbnail ID
+				$thumbnail_id = get_post_meta( $id, '_thumbnail_id', true );
+				if ( ! empty( $thumbnail_id ) ) {
+					$title = sp_get_singular_name( $id );
+					preg_match( '#\((.*?)\)#', $value, $match );
+					// Get the URL of the thumbnail image
+					$custom_image = wp_get_attachment_image( $thumbnail_id, 'sportspress-fit-mini', "", array( "title" => $title ) );
+					if ( ! empty( $custom_image ) && ! empty( $match ) && isset( $match[1] ) ) {
+						$icons = $custom_image . $match[1] . '<br>';			
+					}else{
+						$icons = str_repeat( $custom_image . ' ', intval( $value ) );
+					}
+				}
 			}
 			return $icons;
 		}


### PR DESCRIPTION
Especially when "minutes" was selecred to be shown and  a player was having multiple same performances (i.e. 3 goals)
**Before:** 
![image](https://github.com/user-attachments/assets/4d6f481c-ea63-4544-91e3-ba668a655a29)
**After:**
![image](https://github.com/user-attachments/assets/1eff2ca0-8617-4175-950b-428696fb313a)

