### PR TITLE
Add URL field to iCal (.ics) feed output for sp_event posts

### DIFF
--- a/feeds/ical.php
+++ b/feeds/ical.php
@@ -161,7 +161,8 @@ foreach ( $events as $event ) :
 	"DTSTAMP:19700101T000000\r\n" .
 	'DTSTART:' . mysql2date( $date_format, $event->post_date ) . "\r\n" .
 	'DTEND:' . $end->format( $date_format ) . "\r\n" .
-	'LAST-MODIFIED:' . mysql2date( $date_format, $event->post_modified_gmt ) . "\r\n";
+	'LAST-MODIFIED:' . mysql2date( $date_format, $event->post_modified_gmt ) . "\r\n".
+	'URL:' . esc_url(get_permalink($event->ID)) . "\r\n";
 
 	if ( $description ) {
 		$output .= 'DESCRIPTION:' . $description . "\r\n";


### PR DESCRIPTION
Include a URL: field in each VEVENT entry that points to the permalink of the event (get_permalink($event->ID)).

This addition allows users to quickly access the full event details from their calendar and is compliant with the iCalendar specification (RFC 5545, Section 3.8.4.6) and is supported by most major calendar apps. The addition allows users to quickly access the full event details from their calendar.

addresses #478