### PR TITLE
Feature team metrics

### DIFF
--- a/includes/admin/post-types/class-sp-admin-cpt-team-metric.php
+++ b/includes/admin/post-types/class-sp-admin-cpt-team-metric.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Admin functions for the columns post type
+ *
+ * @author      ThemeBoy
+ * @category    Admin
+ * @package     SportsPress/Admin/Post_Types
+ * @version     2.7.30
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'SP_Admin_CPT' ) ) {
+	require 'class-sp-admin-cpt.php';
+}
+
+if ( ! class_exists( 'SP_Admin_CPT_Team_Metric' ) ) :
+
+	/**
+	 * SP_Admin_CPT_Team_Metric Class
+	 */
+	class SP_Admin_CPT_Team_Metric extends SP_Admin_CPT {
+
+		/**
+		 * Constructor
+		 */
+		public function __construct() {
+			$this->type = 'sp_team_metric';
+
+			// Admin Columns
+			add_filter( 'manage_edit-sp_team_metric_columns', array( $this, 'edit_columns' ) );
+			add_action( 'manage_sp_team_metric_posts_custom_column', array( $this, 'custom_columns' ), 2, 2 );
+
+			// Call SP_Admin_CPT constructor
+			parent::__construct();
+		}
+
+		/**
+		 * Change the columns shown in admin.
+		 */
+		public function edit_columns( $existing_columns ) {
+			$columns = array(
+				'cb'             => '<input type="checkbox" />',
+				'title'          => esc_attr__( 'Label', 'sportspress' ),
+				'sp_key'         => esc_attr__( 'Variable', 'sportspress' ),
+				'sp_description' => esc_attr__( 'Description', 'sportspress' ),
+			);
+			return apply_filters( 'sportspress_team_metric_admin_columns', $columns );
+		}
+
+		/**
+		 * Define our custom columns shown in admin.
+		 *
+		 * @param  string $column
+		 */
+		public function custom_columns( $column, $post_id ) {
+			switch ( $column ) :
+				case 'sp_key':
+					global $post;
+					echo esc_html( $post->post_name );
+					break;
+				case 'sp_description':
+					global $post;
+					echo '<span class="description">' . wp_kses_post( $post->post_excerpt ) . '</span>';
+					break;
+			endswitch;
+		}
+	}
+
+endif;
+
+return new SP_Admin_CPT_Team_Metric();

--- a/includes/admin/post-types/meta-boxes/class-sp-meta-box-team-metrics-details.php
+++ b/includes/admin/post-types/meta-boxes/class-sp-meta-box-team-metrics-details.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Team Metrics Details
+ *
+ * @author      ThemeBoy
+ * @category    Admin
+ * @package     SportsPress/Admin/Meta_Boxes
+ * @version     2.7.30
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'SP_Meta_Box_Config' ) ) {
+	require 'class-sp-meta-box-config.php';
+}
+
+/**
+ * SP_Meta_Box_Team_Metrics_Details
+ */
+class SP_Meta_Box_Team_Metrics_Details extends SP_Meta_Box_Config {
+
+	/**
+	 * Output the metabox
+	 */
+	public static function output( $post ) {
+		wp_nonce_field( 'sportspress_save_data', 'sportspress_meta_nonce' );
+		$visible = get_post_meta( $post->ID, 'sp_visible', true );
+		if ( '' === $visible ) {
+			$visible = 1;
+		}
+		?>
+		<p><strong><?php esc_attr_e( 'Variable', 'sportspress' ); ?></strong></p>
+		<p>
+			<input name="sp_default_key" type="hidden" id="sp_default_key" value="<?php echo esc_attr( $post->post_name ); ?>">
+			<input name="sp_key" type="text" id="sp_key" value="<?php echo esc_attr( $post->post_name ); ?>">
+		</p>
+		<p>
+			<strong><?php esc_attr_e( 'Visible', 'sportspress' ); ?></strong>
+			<i class="dashicons dashicons-editor-help sp-desc-tip" title="<?php esc_attr_e( 'Display in team pages?', 'sportspress' ); ?>"></i>
+		</p>
+		<ul class="sp-visible-selector">
+			<li>
+				<label class="selectit">
+					<input name="sp_visible" id="sp_visible_yes" type="radio" value="1" <?php checked( $visible ); ?>>
+					<?php esc_attr_e( 'Yes', 'sportspress' ); ?>
+				</label>
+			</li>
+			<li>
+				<label class="selectit">
+					<input name="sp_visible" id="sp_visible_no" type="radio" value="0" <?php checked( ! $visible ); ?>>
+					<?php esc_attr_e( 'No', 'sportspress' ); ?>
+				</label>
+			</li>
+		</ul>
+		<?php
+	}
+
+	/**
+	 * Save meta box data
+	 */
+	public static function save( $post_id, $post ) {
+		self::delete_duplicate( $_POST );
+		update_post_meta( $post_id, 'sp_visible', sp_array_value( $_POST, 'sp_visible', 1, 'int' ) );
+	}
+}

--- a/includes/admin/post-types/meta-boxes/class-sp-meta-box-team-metrics.php
+++ b/includes/admin/post-types/meta-boxes/class-sp-meta-box-team-metrics.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Team Metrics
+ *
+ * @author      ThemeBoy
+ * @category    Admin
+ * @package     SportsPress/Admin/Meta_Boxes
+ * @version     2.7.30
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * SP_Meta_Box_Team_Metrics
+ */
+class SP_Meta_Box_Team_Metrics {
+
+	/**
+	 * Output the metabox
+	 */
+	public static function output( $post ) {
+
+		$metrics = get_post_meta( $post->ID, 'sp_team_metrics', true );
+
+		$args = array(
+			'post_type'      => 'sp_team_metric',
+			'numberposts'    => -1,
+			'posts_per_page' => -1,
+			'orderby'        => 'menu_order',
+			'order'          => 'ASC',
+		);
+
+		$vars = get_posts( $args );
+
+		if ( $vars ) :
+			foreach ( $vars as $var ) :
+				?>
+			<p><strong><?php echo esc_html( $var->post_title ); ?></strong></p>
+			<p><input type="text" name="sp_team_metrics[<?php echo esc_attr( $var->post_name ); ?>]" value="<?php echo esc_attr( sp_array_value( $metrics, $var->post_name, '' ) ); ?>" /></p>
+				<?php
+			endforeach;
+		else :
+			sp_post_adder( 'sp_team_metric', esc_attr__( 'Add New', 'sportspress' ) );
+		endif;
+	}
+
+	/**
+	 * Save meta box data
+	 */
+	public static function save( $post_id, $post ) {
+		update_post_meta( $post_id, 'sp_team_metrics', sp_array_value( $_POST, 'sp_team_metrics', array(), 'text' ) );
+	}
+}

--- a/modules/sportspress-team-metrics.php
+++ b/modules/sportspress-team-metrics.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Team Metrics
+ *
+ * @author    ThemeBoy
+ * @category  Modules
+ * @package   SportsPress/Modules
+ * @version   2.7.30
+ */
+
+ // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'SportsPress_Team_Metrics' ) ) :
+
+	/**
+	 * Main SportsPress Team Metrics Class
+	 *
+	 * @class SportsPress_Team_Metrics
+	 * @version 2.7.30
+	 */
+	class SportsPress_Team_Metrics {
+
+
+    }
+    
+endif;
+
+new SportsPress_Team_Metrics();

--- a/modules/sportspress-team-metrics.php
+++ b/modules/sportspress-team-metrics.php
@@ -23,9 +23,234 @@ if ( ! class_exists( 'SportsPress_Team_Metrics' ) ) :
 	 */
 	class SportsPress_Team_Metrics {
 
+        /**
+		 * Constructor
+		 */
+		public function __construct() {
+			// Define constants
+			$this->define_constants();
+
+			// Actions
+			add_action( 'init', array( $this, 'register_post_type' ) );
+			add_action( 'sportspress_config_page', array( $this, 'sp_team_metrics_config' ), 9 );
+			add_action( 'sportspress_include_post_type_handlers', array( $this, 'include_post_type_handler' ) );
+
+			// Filters
+			add_filter( 'sportspress_meta_boxes', array( $this, 'add_meta_boxes' ) );
+			add_filter( 'sportspress_screen_ids', array( $this, 'screen_ids' ) );
+			add_filter( 'sportspress_config_types', array( $this, 'add_post_type' ) );
+			add_filter( 'sportspress_team_details', array( $this, 'team_details' ), 10, 2 );
+		}
+
+		/**
+		 * Define constants.
+		 */
+		private function define_constants() {
+			if ( ! defined( 'SP_TEAM_METRICS_VERSION' ) ) {
+				define( 'SP_TEAM_METRICS_VERSION', '2.7.30' );
+			}
+
+			if ( ! defined( 'SP_TEAM_METRICS_URL' ) ) {
+				define( 'SP_TEAM_METRICS_URL', plugin_dir_url( __FILE__ ) );
+			}
+
+			if ( ! defined( 'SP_TEAM_METRICS_DIR' ) ) {
+				define( 'SP_TEAM_METRICS_DIR', plugin_dir_path( __FILE__ ) );
+			}
+		}
+
+        /**
+		 * Register event specs post type
+		 */
+		public static function register_post_type() {
+			register_post_type(
+				'sp_team_metric',
+				apply_filters(
+					'sportspress_register_post_type_team_metric',
+					array(
+						'labels'              => array(
+							'name'               => esc_attr__( 'Team Metrics', 'sportspress' ),
+							'singular_name'      => esc_attr__( 'Team Metric', 'sportspress' ),
+							'add_new_item'       => esc_attr__( 'Add New Team Metric', 'sportspress' ),
+							'edit_item'          => esc_attr__( 'Edit Team Metric', 'sportspress' ),
+							'new_item'           => esc_attr__( 'New', 'sportspress' ),
+							'view_item'          => esc_attr__( 'View', 'sportspress' ),
+							'search_items'       => esc_attr__( 'Search', 'sportspress' ),
+							'not_found'          => esc_attr__( 'No results found.', 'sportspress' ),
+							'not_found_in_trash' => esc_attr__( 'No results found.', 'sportspress' ),
+						),
+						'public'              => false,
+						'show_ui'             => true,
+						'capability_type'     => 'sp_config',
+						'map_meta_cap'        => true,
+						'publicly_queryable'  => false,
+						'exclude_from_search' => true,
+						'hierarchical'        => false,
+						'supports'            => array( 'title', 'page-attributes', 'excerpt' ),
+						'has_archive'         => false,
+						'show_in_nav_menus'   => false,
+						'can_export'          => false,
+						'show_in_menu'        => false,
+					)
+				)
+			);
+		}
+
+        /**
+		 * Add screen ids.
+		 *
+		 * @return array
+		 */
+		public function screen_ids( $ids ) {
+			return array_merge(
+				$ids,
+				array(
+					'edit-sp_team_metric',
+					'sp_team_metric',
+				)
+			);
+		}
+
+		public static function add_post_type( $post_types = array() ) {
+			$post_types[] = 'sp_team_metric';
+			return $post_types;
+		}
+
+        /**
+		 * Conditonally load the class and functions only needed when viewing this post type.
+		 */
+		public function include_post_type_handler() {
+			include_once SP()->plugin_path() . '/includes/admin/post-types/class-sp-admin-cpt-team-metric.php';
+		}
+
+        /**
+		 * Display Team Metrics Table at Config Page
+		 *
+		 * @return null
+		 */
+		public function sp_team_metrics_config() {
+			?>
+        <table class="form-table">
+            <tbody>
+                <?php
+                $args = array(
+                    'post_type'      => 'sp_team_metric',
+                    'numberposts'    => -1,
+                    'posts_per_page' => -1,
+                    'orderby'        => 'menu_order',
+                    'order'          => 'ASC',
+                );
+                $data = get_posts( $args );
+                ?>
+                <tr valign="top">
+                    <th scope="row" class="titledesc">
+                        <?php esc_attr_e( 'Team Metrics', 'sportspress' ); ?>
+                        <p class="description"><?php esc_attr_e( 'Add more details to a team.', 'sportspress' ); ?></p>
+                    </th>
+                    <td class="forminp">
+                        <table class="widefat sp-admin-config-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col"><?php esc_attr_e( 'Label', 'sportspress' ); ?></th>
+                                    <th scope="col"><?php esc_attr_e( 'Variable', 'sportspress' ); ?></th>
+                                    <th scope="col"><?php esc_attr_e( 'Description', 'sportspress' ); ?></th>
+                                    <th scope="col" class="edit"></th>
+                                </tr>
+                            </thead>
+                            <?php
+                            if ( $data ) :
+                                $i = 0; foreach ( $data as $row ) :
+                                    ?>
+                                <tr
+                                    <?php
+                                    if ( $i % 2 == 0 ) {
+                                        echo ' class="alternate"';}
+                                    ?>
+                                >
+                                    <td class="row-title"><?php echo wp_kses_post( $row->post_title ); ?></td>
+                                    <td><code><?php echo wp_kses_post( $row->post_name ); ?></code></td>
+                                    <td><p class="description"><?php echo wp_kses_post( $row->post_excerpt ); ?></p></td>
+                                    <td class="edit"><a class="button" href="<?php echo esc_url( get_edit_post_link( $row->ID ) ); ?>"><?php esc_attr_e( 'Edit', 'sportspress' ); ?></s></td>
+                                </tr>
+                                    <?php
+                                                        $i++;
+    endforeach; else :
+        ?>
+                                <tr class="alternate">
+                                    <td colspan="4"><?php esc_attr_e( 'No results found.', 'sportspress' ); ?></td>
+                                </tr>
+                            <?php endif; ?>
+                        </table>
+                        <div class="tablenav bottom">
+                            <a class="button alignleft" href="<?php echo esc_url( admin_url( 'edit.php?post_type=sp_team_metric' ) ); ?>"><?php esc_attr_e( 'View All', 'sportspress' ); ?></a>
+                            <a class="button button-primary alignright" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=sp_team_metric' ) ); ?>"><?php esc_attr_e( 'Add New', 'sportspress' ); ?></a>
+                            <br class="clear">
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+			<?php
+		}
+
+        /**
+		 * Add meta boxes.
+		 *
+		 * @return array
+		 */
+		public function add_meta_boxes( $meta_boxes ) {
+			$meta_boxes['sp_team_metric']           = array(
+				'details' => array(
+					'title'    => esc_attr__( 'Team Metrics', 'sportspress' ),
+					'save'     => 'SP_Meta_Box_Team_Metrics_Details::save',
+					'output'   => 'SP_Meta_Box_Team_Metrics_Details::output',
+					'context'  => 'normal',
+					'priority' => 'high',
+				),
+			);
+			$meta_boxes['sp_team']['metrics'] = array(
+				'title'    => esc_attr__( 'Team Metrics', 'sportspress' ),
+				'save'     => 'SP_Meta_Box_Team_Metrics::save',
+				'output'   => 'SP_Meta_Box_Team_Metrics::output',
+				'context'  => 'side',
+				'priority' => 'default',
+			);
+			return $meta_boxes;
+		}
+
+        /**
+		 * Add team details.
+		 *
+		 * @return array
+		 */
+		public function team_details( $data, $id ) {
+			$metrics = $this->team_metrics( $id );
+			return array_merge( $data, $metrics );
+        }
+
+        /**
+         * Returns formatted team metrics
+         *
+         * @access public
+         * @return array
+         */
+        public function team_metrics( $id, $neg = null ) {
+            $metrics       = (array) get_post_meta( $id, 'sp_team_metrics', true );
+            $metric_labels = (array) sp_get_var_labels( 'sp_team_metric', $neg, false );
+            $data        = array();
+
+            foreach ( $metric_labels as $key => $value ) :
+                $metric = sp_array_value( $metrics, $key, null );
+                if ( $metric == null ) {
+                    continue;
+                }
+                $data[ $value ] = sp_array_value( $metrics, $key, '&nbsp;' );
+            endforeach;
+            return $data;
+        }
 
     }
-    
+
 endif;
 
 new SportsPress_Team_Metrics();

--- a/modules/sportspress-team-metrics.php
+++ b/modules/sportspress-team-metrics.php
@@ -153,6 +153,7 @@ if ( ! class_exists( 'SportsPress_Team_Metrics' ) ) :
                                 <tr>
                                     <th scope="col"><?php esc_attr_e( 'Label', 'sportspress' ); ?></th>
                                     <th scope="col"><?php esc_attr_e( 'Variable', 'sportspress' ); ?></th>
+                                    <th scope="col"><?php esc_attr_e( 'Visible', 'sportspress' ); ?></th>
                                     <th scope="col"><?php esc_attr_e( 'Description', 'sportspress' ); ?></th>
                                     <th scope="col" class="edit"></th>
                                 </tr>
@@ -169,6 +170,15 @@ if ( ! class_exists( 'SportsPress_Team_Metrics' ) ) :
                                 >
                                     <td class="row-title"><?php echo wp_kses_post( $row->post_title ); ?></td>
                                     <td><code><?php echo wp_kses_post( $row->post_name ); ?></code></td>
+                                    <td>
+                                        <?php
+                                        if ( get_post_meta( $row->ID, 'sp_visible', true ) ) {
+                                            echo '<i class="dashicons dashicons-yes"></i>';
+                                        } else {
+                                            echo '&nbsp;';
+                                        }
+                                        ?>
+                                    </td>
                                     <td><p class="description"><?php echo wp_kses_post( $row->post_excerpt ); ?></p></td>
                                     <td class="edit"><a class="button" href="<?php echo esc_url( get_edit_post_link( $row->ID ) ); ?>"><?php esc_attr_e( 'Edit', 'sportspress' ); ?></s></td>
                                 </tr>

--- a/templates/team-details.php
+++ b/templates/team-details.php
@@ -4,7 +4,7 @@
  *
  * @author      ThemeBoy
  * @package     SportsPress/Templates
- * @version   2.7.1
+ * @version   2.7.30
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -50,6 +50,9 @@ if ( $terms ) :
 		$data[ esc_attr__( 'Home', 'sportspress' ) ] = implode( ', ', $venues );
 	endif;
 endif;
+
+// Give the option to add more details to the team details.
+$data = apply_filters( 'sportspress_team_details', $data, $id );
 
 $output = '<div class="sp-list-wrapper">' .
 	'<dl class="sp-team-details">';


### PR DESCRIPTION
Add the ability to users to add more info to their teams through metrics (in similar way that already is possible with players). This extra info will be shown in team's page. (see screenshots)
<img width="3473" height="434" alt="image" src="https://github.com/user-attachments/assets/f5abba33-bcca-4477-a383-904a39862a6a" />
<img width="615" height="458" alt="image" src="https://github.com/user-attachments/assets/d7aa9824-49e7-4bd4-b7d7-2b1498c16f3c" />
<img width="1768" height="527" alt="image" src="https://github.com/user-attachments/assets/cb2b5098-5d0a-40ca-a5d4-d9d6903a403d" />

Requested by: https://wordpress.org/support/topic/feature-request-add-custom-metrics-for-team-profiles/
